### PR TITLE
Specify older numpy version to avoid incompatibility with pandas.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 import os
 
 dependencies = ['click', 'selenium', 'beautifulsoup4', 'pandas',
-                'requests', 'fake-useragent']
+                'numpy==1.14.3', 'requests', 'fake-useragent']
 
 setup(
     name='python-instagram-crawler',


### PR DESCRIPTION
- Specify numpy version 1.14.3 to avoid pandas incompatibility with version 1.15.0