### PR TITLE
Fix typo (missing comma) in driver service args.

### DIFF
--- a/instagram_crawler/cli.py
+++ b/instagram_crawler/cli.py
@@ -185,7 +185,7 @@ def get_driver():
         service_log_path=os.path.devnull,
         service_args=[
             '--ignore-ssl-errors=true',
-            '--ssl-protocol=any'
+            '--ssl-protocol=any',
             '--cookies-file={0}'.format(cookie_path)
         ]
     )


### PR DESCRIPTION
Add missing comma in service args list for webdriver that prevented the cookies file path from being set. This in turn caused an intermittent bad file descriptor error when closing the webdriver.